### PR TITLE
fix the --force option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rockervsc"
-version = "0.4.0"
+version = "0.5.0"
 authors = [{ name = "Austin Gregg-Smith", email = "blooop@gmail.com" }]
 description = "A rocker wrapper for launching and attaching vscode to a rocker container"
 readme = "README.md"
@@ -53,7 +53,7 @@ build-backend = "hatchling.build"
 include = ["rockervsc"]
 
 [project.scripts]
-rockervsc = "rockervsc.rockervsc:run_rockervsc"
+rockervsc = "rockervsc.rockervsc:main"
 
 # Environments
 [tool.pixi.environments]


### PR DESCRIPTION
## Summary by Sourcery

Fixes the `--force` option to correctly rename the existing container when it is enabled, and adds an argument parser to handle command line arguments.

Bug Fixes:
- Fixes the `--force` option to correctly rename the existing container when it is enabled.

Enhancements:
- Adds an argument parser to handle command line arguments.